### PR TITLE
Pass list of ignored rules and hadolint flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ With `reporter: github-pr-review` a comment is added to the Pull Request Convers
 
 Optional. `${{ github.token }}` is used by default.
 
+### `hadolint_flags`
+
+Optional. Pass hadolint flags:
+```
+with:
+  hadolint_flags: --thrusted-repository docker.io
+```
+
+### `hadolint_ignore`
+
+Optional. Pass hadolint rules to ignore them:
+```
+with:
+  hadolint_ignore: DL3009 DL3008
+```
+
 ### `tool_name`
 
 Optional. Tool name to use for reviewdog reporter. Useful when running multiple

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: 'GITHUB_TOKEN.'
     default: '${{ github.token }}'
   hadolint_flags:
-    description: 'Hadolint flags. (hadolint <rubocop_flags>)'
+    description: 'Hadolint flags. (hadolint <hadolint_flags>)'
     default: ''
   hadolint_ignore:
     description: 'List of ignored rules. (hadolint --ignore RULE1 --ignore RULE2)'

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,12 @@ inputs:
   github_token:
     description: 'GITHUB_TOKEN.'
     default: '${{ github.token }}'
+  hadolint_flags:
+    description: 'Hadolint flags. (hadolint <rubocop_flags>)'
+    default: ''
+  hadolint_ignore:
+    description: 'List of ignored rules. (hadolint --ignore RULE1 --ignore RULE2)'
+    default: ''
   tool_name:
     description: 'Tool name to use for reviewdog reporter'
     default: 'hadolint'
@@ -34,6 +40,8 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.github_token }}
+    - ${{ inputs.hadolint_flags }}
+    - ${{ inputs.hadolint_ignore }}
     - ${{ inputs.tool_name }}
     - ${{ inputs.level }}
     - ${{ inputs.reporter }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,14 @@
 cd "$GITHUB_WORKSPACE"
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-git ls-files --exclude='Dockerfile*' --ignored | xargs hadolint \
+IGNORE_LIST=""
+for rule in $INPUT_HADOLINT_IGNORE; do
+  IGNORE_LIST="$IGNORE_LIST --ignore $rule"
+done
+
+INPUT_HADOLINT_FLAGS="$INPUT_HADOLINT_FLAGS $IGNORE_LIST"
+
+git ls-files --exclude='Dockerfile*' --ignored | xargs hadolint ${INPUT_HADOLINT_FLAGS} \
   | reviewdog -efm="%f:%l %m" \
     -name="${INPUT_TOOL_NAME}" \
     -reporter="${INPUT_REPORTER}" \


### PR DESCRIPTION
Added ability to:
* pass list of ignored rules (i.e. `DL3018 DL3009`)
* pass hadolint flags in general (i.e. `--trusted-registry docker.io`)

Updated readme.