### PR TITLE
Add ability to exclude folders and files to check

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Optional. List of folders and files to exclude from checking.
 
 Use `/%FOLDER%/*` to exclude whole folder or `%FILENAME%` to exclude certain files. 
 
-Note that you can use wildcard to exclude certain file extensions, like `Dockerfile.*` will exclude `Dockerfile.dev`, but will not exclude `Dockerfile`
+Note that you can use wildcard to exclude certain file extensions, like `Dockerfile.*` will exclude `Dockerfile.dev`, but will not exclude `Dockerfile`.
 
-You can combine those rules as you wish (i.e. exclude certain files from certain folders only)
+You can combine those rules as you wish (i.e. exclude certain files from certain folders only):
 ```yaml
 with:
   exclude: |

--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ Optional. `${{ github.token }}` is used by default.
 Optional. Tool name to use for reviewdog reporter. Useful when running multiple
 actions with different config.
 
+### `exclude`
+
+Optional. List of folders and files to exclude from checking.
+
+Use `/%FOLDER%/*` to exclude whole folder or `%FILENAME%` to exclude certain files. 
+
+Note that you can use wildcard to exclude certain file extensions, like `Dockerfile.*` will exclude `Dockerfile.dev`, but will not exclude `Dockerfile`
+
+You can combine those rules as you wish (i.e. exclude certain files from certain folders only)
+```yaml
+with:
+  exclude: |
+    /vendor/*
+    Dockerfile.*
+```
+
 ### `level`
 
 Optional. Report level for reviewdog [`info`, `warning`, `error`].

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   tool_name:
     description: 'Tool name to use for reviewdog reporter'
     default: 'hadolint'
+  exclude:
+    description: 'List of files and folders to exclude'
+    default: ''
   level:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
@@ -35,6 +38,7 @@ runs:
   args:
     - ${{ inputs.github_token }}
     - ${{ inputs.tool_name }}
+    - ${{ inputs.exclude }}
     - ${{ inputs.level }}
     - ${{ inputs.reporter }}
     - ${{ inputs.filter_mode }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,13 @@
 cd "$GITHUB_WORKSPACE"
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-git ls-files --exclude='Dockerfile*' --ignored | xargs hadolint \
+EXCLUDES=""
+for exclude_path in $INPUT_EXCLUDE; do
+  EXCLUDES="EXCLUDES --exclude='!$exclude_path'"
+done
+
+git ls-files --exclude='Dockerfile*' --ignored ${EXCLUDES} \
+  | xargs hadolint \
   | reviewdog -efm="%f:%l %m" \
     -name="${INPUT_TOOL_NAME}" \
     -reporter="${INPUT_REPORTER}" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 EXCLUDES=""
 for exclude_path in $INPUT_EXCLUDE; do
-  EXCLUDES="EXCLUDES --exclude='!$exclude_path'"
+  EXCLUDES="$EXCLUDES --exclude='!$exclude_path'"
 done
 
 IGNORE_LIST=""


### PR DESCRIPTION
From the issue https://github.com/reviewdog/action-hadolint/issues/16
How it works: we exclude files and folders using consecutive `--exclude` rules for `git ls-files`. Like so:

```
with:
  exclude: |
    /vendor/*
    Dockerfile.*
```

That's how it looks like:

```
git ls-files --exclude='Dockerfile*' --ignored 
Dockerfile
vendor/Dockerfile
vendor/Dockerfile.bak

git ls-files --exclude='Dockerfile*' --ignored --exclude='!/vendor/Dockerfile*'
Dockerfile

git ls-files --exclude='Dockerfile*' --ignored --exclude='!/vendor/*'           
Dockerfile

git ls-files --exclude='Dockerfile*' --ignored --exclude='!/vendor/Dockerfile.*'
Dockerfile
vendor/Dockerfile
```