### PR TITLE
Match files ending with `Dockerfile`

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ done
 
 INPUT_HADOLINT_FLAGS="$INPUT_HADOLINT_FLAGS $IGNORE_LIST"
 
-git ls-files --exclude='Dockerfile*' --ignored ${EXCLUDES} \
+git ls-files --exclude='*Dockerfile*' --ignored ${EXCLUDES} \
   | xargs hadolint ${INPUT_HADOLINT_FLAGS} \
   | reviewdog -efm="%f:%l %m" \
     -name="${INPUT_TOOL_NAME}" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-cd "$GITHUB_WORKSPACE"
+cd "$GITHUB_WORKSPACE" || exit
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 EXCLUDES=""
@@ -15,12 +15,12 @@ done
 
 INPUT_HADOLINT_FLAGS="$INPUT_HADOLINT_FLAGS $IGNORE_LIST"
 
-git ls-files --exclude='*Dockerfile*' --ignored ${EXCLUDES} \
-  | xargs hadolint ${INPUT_HADOLINT_FLAGS} \
+git ls-files --exclude='*Dockerfile*' --ignored "${EXCLUDES}" \
+  | xargs hadolint "${INPUT_HADOLINT_FLAGS}" \
   | reviewdog -efm="%f:%l %m" \
     -name="${INPUT_TOOL_NAME}" \
     -reporter="${INPUT_REPORTER}" \
     -filter-mode="${INPUT_FILTER_MODE}" \
     -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
     -level="${INPUT_LEVEL}" \
-    ${INPUT_REVIEWDOG_FLAGS}
+    "${INPUT_REVIEWDOG_FLAGS}"


### PR DESCRIPTION
Some projects name their Dockerfiles like `name.Dockerfile`.

This change edits the glob to also match those files when running the
action.