### PR TITLE
Bump hadolint to v2.4.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
       shell: sh
       env:
         REVIEWDOG_VERSION: v0.11.0
-        HADOLINT_VERSION: v2.3.0
+        HADOLINT_VERSION: v2.4.0
         # INPUT_<VARIABLE_NAME> is not available in Composite run steps
         # https://github.community/t/input-variable-name-is-not-available-in-composite-run-steps/127611
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}


### PR DESCRIPTION
## What

Bumped the hadolint to the latest version `v2.4.0`.

The new hadolint has released and has nice features (like failure threshold). Therefore, I want to support that.

Thanks in advance.

## Ref

* [v2.4.0, hadolint/hadolint](https://github.com/hadolint/hadolint/releases/tag/v2.4.0)