### PR TITLE
Fix an error with using git ls-files

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -31,7 +31,7 @@ done
 INPUT_HADOLINT_FLAGS="$INPUT_HADOLINT_FLAGS $IGNORE_LIST"
 
 echo '::group:: Running hadolint with reviewdog 🐶 ...'
-git ls-files --exclude='*Dockerfile*' --ignored ${EXCLUDES} \
+git ls-files --exclude='*Dockerfile*' --ignored --cached ${EXCLUDES} \
   | xargs hadolint -f json ${INPUT_HADOLINT_FLAGS} \
   | jq -f "${GITHUB_ACTION_PATH}/to-rdjson.jq" -c \
   | reviewdog -f="rdjson" \


### PR DESCRIPTION
```
fatal: ls-files -i must be used with either -o or -c
```