### PR TITLE
Add include option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ with:
     Dockerfile.*
 ```
 
+### `include`
+
+Optional. Defaults to `*Dockerfile*`. List of folders and files to use for checking.
+
+Use `/%FOLDER%/*` to include whole folder or `%FILENAME%` to include certain files.
+
+Note that you can use wildcard to include certain file extensions, like `Dockerfile.*` will include `Dockerfile.dev`, but will not include `Dockerfile`.
+
+You can combine those rules as you wish (i.e. exclude certain files from certain folders only):
+```yaml
+with:
+  include: |
+    subfolder/Dockerfile.*
+```
+
 ### `level`
 
 Optional. Report level for reviewdog [`info`, `warning`, `error`].

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   exclude:
     description: 'List of files and folders to exclude'
     default: ''
+  include:
+    description: 'List of files and folders to include'
+    default: '*Dockerfile*'
   level:
     description: 'Report level for reviewdog [info,warning,error]'
     default: 'error'
@@ -50,6 +53,7 @@ runs:
         # https://github.community/t/input-variable-name-is-not-available-in-composite-run-steps/127611
         INPUT_GITHUB_TOKEN: ${{ inputs.github_token }}
         INPUT_EXCLUDE: ${{ inputs.exclude }}
+        INPUT_INCLUDE: ${{ inputs.include }}
         INPUT_HADOLINT_IGNORE: ${{ inputs.hadolint_ignore }}
         INPUT_HADOLINT_FLAGS: ${{ inputs.hadolint_flags }}
         INPUT_TOOL_NAME: ${{ inputs.tool_name }}

--- a/script.sh
+++ b/script.sh
@@ -24,6 +24,12 @@ for exclude_path in $INPUT_EXCLUDE; do
   EXCLUDES="$EXCLUDES $*"
 done
 
+INCLUDES=""
+for include_path in $INPUT_INCLUDE; do
+  set -- --exclude="${include_path}"
+  INCLUDES="$INCLUDES $*"
+done
+
 IGNORE_LIST=""
 for rule in $INPUT_HADOLINT_IGNORE; do
   IGNORE_LIST="$IGNORE_LIST --ignore $rule"
@@ -32,7 +38,7 @@ done
 INPUT_HADOLINT_FLAGS="$INPUT_HADOLINT_FLAGS $IGNORE_LIST"
 
 echo '::group:: Running hadolint with reviewdog 🐶 ...'
-git ls-files --exclude='*Dockerfile*' --ignored --cached ${EXCLUDES} \
+git ls-files ${INCLUDES} --ignored --cached ${EXCLUDES} \
   | xargs hadolint -f json ${INPUT_HADOLINT_FLAGS} \
   | jq -f "${GITHUB_ACTION_PATH}/to-rdjson.jq" -c \
   | reviewdog -f="rdjson" \


### PR DESCRIPTION
This is useful if running Hadolint across different directories, such as in a matrix action on a monorepo, as an example of why this was needed: https://github.com/USA-RedDragon/dockers/blob/604e7e8cfbc10f5503401b9d3e4f823074b5908a/.github/workflows/linting.yml#L41-L64

Prior behavior caused Hadolint to run against all files in the repo with no way to filter it down to exclusively check in the appropriate matrix path